### PR TITLE
Codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,10 +280,16 @@ be found at [https://hexdocs.pm/rid](https://hexdocs.pm/rid)
 
 The tests for this module are a combination of doctests, unit tests and property based tests.
 
-To run the property based tests you will need an installation of [IPFS](https://ipfs.io/).
+To run the property based tests you will need to install [IPFS](https://ipfs.io/).
 See https://github.com/dwyl/learn-ipfs#how for details.
 
-Then you can run `mix all_tests`, which will run the `Cid.cid` function on 100 randomly generated strings and maps, comparing the results of these to the IPFS generated cid, ensuring our function is correct in its implementation.
+The property based tests will run by default. These tests are more comprehensive
+when compared to the "regular" tests. They will run the `Cid.cid` function on
+100 randomly generated strings and maps, comparing the results of these to the
+IPFS generated cid, ensuring our function is correct in its implementation.
+
+These tests take a little longer to run that the "regular" tests, so if you wish
+you can skip them with `mix test --exclude ipfs`
 
 # Research, Background & Relevant Reading
 + Real World examples of services that use Strings as IDs instead of Integers. [Real World Examples](https://github.com/dwyl/cid/blob/master/read_world_examples.md)

--- a/mix.exs
+++ b/mix.exs
@@ -8,15 +8,10 @@ defmodule Cid.MixProject do
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
-      aliases: aliases(),
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [
         coveralls: :test,
-        "coveralls.detail": :test,
-        "coveralls.post": :test,
-        "coveralls.html": :test,
         "coveralls.json": :test,
-        all_tests: :test
       ]
     ]
   end
@@ -36,13 +31,6 @@ defmodule Cid.MixProject do
       {:basefiftyeight, "~> 0.1.0"}, # Currenly building our own version of this here https://git.io/fhPaK. Can replace when it is ready
       {:excoveralls, "~> 0.10", only: :test},
       {:stream_data, "~> 0.4.2", only: :test}
-    ]
-  end
-
-  defp aliases do
-    [
-      test: ["coveralls --exclude ipfs"],
-      all_tests: ["coveralls.detail --include ipfs", "coveralls.json"]
     ]
   end
 end


### PR DESCRIPTION
Removes aliases (including our own version of the test alias which was causing codecov to fail when run on travis)

update readme

#28 