### PR TITLE
Use b58 dependency

### DIFF
--- a/lib/cid.ex
+++ b/lib/cid.ex
@@ -86,7 +86,7 @@ defmodule Cid do
   defp create_cid(multihash) when is_binary(multihash) do
     multihash
     |> create_cid_suffix()
-    |> B58.encode58()
+    |> Base58Encode.encode()
     |> add_multibase_prefix()
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,7 @@ defmodule Cid.MixProject do
     [
       {:ex_multihash, "~> 2.0"},
       {:jason, "~> 1.1"},
-      {:basefiftyeight, "~> 0.1.0"}, # Currenly building our own version of this here https://git.io/fhPaK. Can replace when it is ready
+      {:b58, "~> 0.1.1"},
       {:excoveralls, "~> 0.10", only: :test},
       {:stream_data, "~> 0.4.2", only: :test}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{
-  "basefiftyeight": {:hex, :basefiftyeight, "0.1.0", "3d48544743bf9aab7ab02aed803ac42af77acf268c7d8c71d4f39e7fa85ee8d3", [:mix], [], "hexpm"},
+  "b58": {:hex, :b58, "0.1.1", "950563b90ad95be214143aa807d16c98d2ac7bab915097cb1461c936128c6b90", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.4.2", "75424ff0f3baaccfd34b1214184b6ef616d89e420b258bb0a5ea7d7bc628f7f0", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_multihash": {:hex, :ex_multihash, "2.0.0", "7fb36f842a2ec1c6bbba550f28fcd16d3c62981781b9466c9c1975c43d7db43c", [:mix], [], "hexpm"},
   "excoveralls": {:hex, :excoveralls, "0.10.4", "b86230f0978bbc630c139af5066af7cd74fd16536f71bc047d1037091f9f63a9", [:mix], [{:hackney, "~> 1.13", [hex: :hackney, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
ref: #23 

Use https://hex.pm/packages/b58 to encode CID in base58