### PR TITLE
Define cid v1 using base32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ erl_crash.dump
 *.ez
 *.beam
 /config/*.secret.exs
+random.txt

--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@ end
 
 and run `mix deps.get`
 
-2. Call the `cid/1` function with a string, map, or struct as a parameter...
+2. Define in your mix configuration which base you want to use to create the cid.
+The value of the base should be the either `:base32` or `:base58`.
+If the base is not defined then `excid` will use the `base32` by default.
+
+```elixir
+config :excid, base: :base32
+```
+3. Call the `cid/1` function with a string, map, or struct as a parameter...
 
 ```
 Cid.cid("hello")

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Cid.MixProject do
   def project do
     [
       app: :excid,
-      version: "0.1.0",
+      version: "0.2.0",
       package: package(),
       description: description(),
       elixir: "~> 1.7",


### PR DESCRIPTION
ref: #36 
Create a cid v1 with base32.
You can specify which base you want to use in your config
`config :excid, base: :base32`
or
`config :excid, base: :base58`

By default if the config is not defined then the base32 will be used